### PR TITLE
Track requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Local Responder
 
-Local Responder is a helper function that creates a simple web server with just
-one view that has only one purpose, to return simple data.
+Local Responder is a helper context manager that creates a web server with just
+one view that has only one purpose, to return simple predefined data.
 
 This is created just for the purpose of using in tests, to mock out an API in a
-very simple manner.
+very simple manner. It's mostly useful for a blackbox like test where you are
+mocking out an external API while making requests to the "blackbox" api.
 
 ## Usage
 


### PR DESCRIPTION
Support for tracking requests made to views. Closes #1.

```python
    async with respond(text="Hello, there!") as api:
        await session.get("http://localhost:5000/", params={"foo": "bar"})
        assert len(api.calls) == 1
        assert api.calls[0].query == {"foo": "bar"}

    async with respond(text="Hello, there!", method="post") as api:
        await session.post("http://localhost:5000/", json={"foo": "bar"})
        assert len(api.calls) == 1
        assert api.calls[0].json == {"foo": "bar"}

```